### PR TITLE
Ioarray2

### DIFF
--- a/Simulator/Evaluate.hs
+++ b/Simulator/Evaluate.hs
@@ -80,15 +80,11 @@ instance Eval (T.Expr ty) (IO Val) where
     eval (T.BinBitBool _ _ _ e1 e2) = liftM BoolVal $ liftM2 (BV.<.) (liftM bvCoerce $ eval e1) (liftM bvCoerce $ eval e2) --only works a.t.m. because there is only one BinBitBoolOp
     eval (T.ITE _ e1 e2 e3) = do
         b <- eval e1
-        if boolCoerce b then eval e2 else eval e2
+        if boolCoerce b then eval e2 else eval e3
     eval (T.Eq _ e1 e2) = do
         v1 <- eval e1
         v2 <- eval e2
-        return $ case v1 of
-                    BoolVal b -> BoolVal $ b == (boolCoerce $ v2)
-                    BVVal v -> BoolVal $ v == (bvCoerce $ v2)
-                    StructVal s -> BoolVal $ s == (structCoerce $ v2)
-                    ArrayVal a -> BoolVal $ a == (arrayCoerce $ v2)
+        liftM BoolVal $ v1 .== v2
     eval (T.ReadStruct _ _ names e i) = do
         v <- eval e
         return $ case lookup (names i) (structCoerce v) of

--- a/Simulator/RegisterFile.hs
+++ b/Simulator/RegisterFile.hs
@@ -10,15 +10,16 @@ import qualified HaskellTarget as T
 
 import qualified Data.BitVector as BV
 import qualified Data.HashMap as M
-import qualified Data.Vector as V
+import qualified Data.Array.MArray as MA
+import qualified Data.Array.IO as A
 
+import Control.Monad
 import Data.Foldable (foldrM)
 import Data.Maybe (fromJust, catMaybes)
 import System.Environment (getArgs)
 
 data RegFile = RegFile {
       fileName :: String
---    , offset :: Int
     , isWrMask :: Bool
     , chunkSize :: Int
     , readers :: T.RegFileReaders
@@ -30,7 +31,7 @@ data RegFile = RegFile {
 data FileState = FileState {
       methods :: M.Map String (FileCall,String) -- map between method names and method type + filename
     , int_regs :: M.Map String Val -- map between intermediate registers and their values
-    , arrs :: M.Map String (V.Vector Val) -- map between filenames and arrays
+    , arrs :: M.Map String (A.IOArray Int Val) -- map between filenames and arrays
     , files :: M.Map String RegFile -- map between filenames and files
 }
 
@@ -46,19 +47,18 @@ data FileCall = AsyncRead | ReadReq String | ReadResp String | Write
 
 data FileUpd = IntRegWrite String Val | ArrWrite String [(Int, Val)]
 
-array_of_file :: FileState -> RegFile -> V.Vector Val
+array_of_file :: FileState -> RegFile -> A.IOArray Int Val
 array_of_file state file =
     case M.lookup (fileName file) (arrs state) of
         Just arr -> arr
         Nothing -> error $ "File " ++ fileName file ++ " not found in current state."
 
-file_async_read :: FileState -> RegFile -> Int -> V.Vector Val
+file_async_read :: FileState -> RegFile -> Int -> IO (A.IOArray Int Val)
 file_async_read state file i 
     | i < 0 = error "Read out of bounds."
-    | otherwise = V.slice i (chunkSize file) (array_of_file state file)
+    | otherwise = slice i (chunkSize file) (array_of_file state file)
 
-
-file_sync_readreq :: Val -> FileState -> RegFile -> String -> Val
+file_sync_readreq :: Val -> FileState -> RegFile -> String -> IO Val
 file_sync_readreq val state file regName = case readers file of
     T.Async _ -> error "Async encountered when Sync was expected."
     T.Sync isAddr rs -> if isAddr
@@ -66,18 +66,16 @@ file_sync_readreq val state file regName = case readers file of
         then
 
             --isAddr = True
-            val
+            return val
 
         else
 
             --isAddr = False
-            ArrayVal $ V.slice (fromIntegral i) (chunkSize file) (array_of_file state file)
+            liftM ArrayVal $ slice (fromIntegral i) (chunkSize file) (array_of_file state file)
 
                 where i = BV.nat $ bvCoerce val
 
-
-
-file_sync_readresp :: FileState -> RegFile -> String -> Val
+file_sync_readresp :: FileState -> RegFile -> String -> IO Val
 file_sync_readresp state file regName = case readers file of
     T.Async _ -> error "Async encountered when Sync was expected."
     T.Sync isAddr rs -> if isAddr
@@ -86,7 +84,7 @@ file_sync_readresp state file regName = case readers file of
 
             --isAddr = True
             case M.lookup regName $ int_regs state of
-                Just v -> ArrayVal $ V.slice (fromIntegral i) (chunkSize file) (array_of_file state file)
+                Just v -> liftM ArrayVal $ slice (fromIntegral i) (chunkSize file) (array_of_file state file)
 
                     where i = BV.nat $ bvCoerce v
 
@@ -96,27 +94,27 @@ file_sync_readresp state file regName = case readers file of
 
             --isAddr = False
             case M.lookup regName $ int_regs state of
-                Just v -> v
+                Just v -> return v
                 Nothing -> error $ "Register " ++ regName ++ " not found."
 
-file_writes_mask :: RegFile -> Int -> V.Vector Bool -> V.Vector Val -> [(Int,Val)]
-file_writes_mask file i mask vals =
-    map (\j -> (i+j, vals V.! j)) $ filter (mask V.!) [0..(chunkSize file - 1)]
+file_writes_mask :: RegFile -> Int -> A.IOArray Int Bool -> A.IOArray Int Val -> IO [(Int,Val)]
+file_writes_mask file i mask vals = do
+    mask_indices <- filterM (MA.readArray mask) [0..(chunkSize file - 1)] 
+    pair_sequence $ map (\j -> (i+j, MA.readArray vals j)) mask_indices
 
-file_writes_no_mask :: RegFile -> Int -> V.Vector Val -> [(Int,Val)]
+file_writes_no_mask :: RegFile -> Int -> A.IOArray Int Val -> IO [(Int,Val)]
 file_writes_no_mask file i vals =
-    map (\j -> (i+j, vals V.! j)) [0 .. (chunkSize file - 1)]
+   pair_sequence $ map (\j -> (i+j, MA.readArray vals j)) [0 .. (chunkSize file - 1)]
 
-
-rf_methcall :: FileState -> String -> Val -> Maybe (Maybe FileUpd,Val)
+rf_methcall :: FileState -> String -> Val -> Maybe (Maybe (IO FileUpd), IO Val)
 rf_methcall state methName val =
     case M.lookup methName $ methods state of
         Just (fc, fileName) -> 
             case fc of
-                AsyncRead -> Just (Nothing, ArrayVal $ file_async_read state (file_of_fname fileName) arg_index)
-                ReadReq regName -> Just (Just $ IntRegWrite regName $ file_sync_readreq val state (file_of_fname fileName) regName, BVVal $ BV.nil)
+                AsyncRead -> Just (Nothing, liftM ArrayVal $ file_async_read state (file_of_fname fileName) arg_index)
+                ReadReq regName -> Just (Just $ liftM2 IntRegWrite (pure regName) $ file_sync_readreq val state (file_of_fname fileName) regName, return $ BVVal $ BV.nil)
                 ReadResp regName -> Just (Nothing, file_sync_readresp state (file_of_fname fileName) regName)
-                Write -> Just (Just $ ArrWrite fileName (writes fileName) , BVVal BV.nil)
+                Write -> Just (Just $ liftM2 ArrWrite (pure fileName) (writes fileName) , return $ BVVal BV.nil)
         Nothing -> Nothing
 
     where 
@@ -134,16 +132,21 @@ rf_methcall state methName val =
 
         arg_data = arrayCoerce $ struct_field_access "data" val
 
-        arg_mask = V.map boolCoerce $ arrayCoerce $ struct_field_access "mask" val
+        arg_mask = undefined
 
-exec_file_update :: FileUpd -> FileState -> FileState
+        --arg_mask = V.map boolCoerce $ arrayCoerce $ struct_field_access "mask" val
+
+
+exec_file_update :: FileUpd -> FileState -> IO FileState
 exec_file_update (IntRegWrite regName v) state =
-    state { int_regs = M.adjust (const v) regName $ int_regs state }
-exec_file_update (ArrWrite fileName changes) state =
-    state { arrs = M.adjust (flip (V.//) changes) fileName $ arrs state }
+    return $ state { int_regs = M.adjust (const v) regName $ int_regs state }
+exec_file_update (ArrWrite fileName changes) state = do
+    let arr = arrs state M.! fileName
+    do_writes arr changes
+    return state
 
-exec_file_updates :: FileState -> [FileUpd] -> FileState
-exec_file_updates = foldr exec_file_update
+exec_file_updates :: FileState -> [FileUpd] -> IO FileState
+exec_file_updates = foldrM exec_file_update
 
 process_args :: [String] -> [(String,String)]
 process_args = catMaybes . map (binary_split '=')
@@ -181,7 +184,7 @@ initialize_file modes args rfb@(T.Build_RegFileBase rfIsWrMask rfNum rfDataArray
                     T.Async _ -> return []
                     T.Sync b rs -> mapM (\r -> do
                                                 let debug = debug_mode modes
-                                                v <- (if debug then (pure . defVal) else randVal) (if b then T.Bit (log2 $ rfIdxNum) else rfData)
+                                                v <- (if debug then defVal else randVal) (if b then T.Bit (log2 $ rfIdxNum) else rfData)
                                                 return (T.readRegName r, v)) rs
 
     return $ state {
@@ -196,9 +199,11 @@ initialize_file modes args rfb@(T.Build_RegFileBase rfIsWrMask rfNum rfDataArray
         array = case rfInit of
             T.RFNonFile Nothing -> do
                 let debug = debug_mode modes
-                vs <- mapM (if debug then (pure . defVal) else randVal) $ V.replicate (rfIdxNum) (rfData)
-                return vs
-            T.RFNonFile (Just c) -> return $ V.replicate (rfIdxNum) (eval c)
+                dv <- defVal rfData
+                MA.newArray (0,rfIdxNum-1) dv --TODO: add random vals back in
+            T.RFNonFile (Just c) -> do
+                v <- eval c
+                MA.newArray (0,rfIdxNum-1) v
             T.RFFile isAscii isArg file _ _ _ -> 
                 parseHex isAscii (rfData) (rfIdxNum) filepath
 

--- a/Simulator/Simulator.hs
+++ b/Simulator/Simulator.hs
@@ -35,27 +35,38 @@ get_rules (x:xs) rules = case lookup x rules of
 
 initialize :: Modes -> T.RegInitT -> IO (String,Val)
 initialize _ (regName, (_, Just (T.NativeConst c))) = return (regName, unsafeCoerce c)
-initialize _ (regName, (_, Just (T.SyntaxConst _ c))) = return (regName, eval c)
+initialize _ (regName, (_, Just (T.SyntaxConst _ c))) = do
+    v <- eval c
+    return (regName, v)
 initialize modes (regName, (k, Nothing)) = do
     let debug = debug_mode modes
-    v <- (if debug then (pure . defVal_FK) else randVal_FK) k
+    v <- (if debug then defVal_FK else randVal_FK) k
     return (regName,v)
 
 simulate_action :: AbstractEnvironment a => [String] -> Modes -> IORef a -> FileState -> [(String, a -> Val -> FileState -> M.Map String Val -> IO (a, Val))] -> T.ActionT Val -> M.Map String Val -> IO ([String], [(String,Val)], [FileUpd] ,Val)
 simulate_action methcalls modes envRef state meths act regs = sim methcalls act [] [] where
 
-    sim mcs (T.MCall methName _ arg cont) updates fupdates = if methName `elem` mcs then error ("Method " ++ methName  ++ " called twice in same cycle.") else case rf_methcall state methName (eval arg) of
-        Just (Nothing,v) -> sim (methName:mcs) (cont v) updates fupdates
-        Just (Just u,v) -> sim (methName:mcs) (cont v) updates (u:fupdates)
-        Nothing -> case lookup methName meths of
-            Nothing -> error ("Method " ++ methName ++ " not found.")
-            Just f -> do
-                currEnv <- readIORef envRef
-                (nextEnv, v) <- f currEnv (eval arg) state regs
-                writeIORef envRef nextEnv
-                sim (methName:mcs) (cont v) updates fupdates
+    sim mcs (T.MCall methName _ arg cont) updates fupdates = if methName `elem` mcs then error ("Method " ++ methName  ++ " called twice in same cycle.") else do
+        arg' <- eval arg
+        case rf_methcall state methName arg' of
+            Just (Nothing,v) -> do 
+                v' <- v
+                sim (methName:mcs) (cont v') updates fupdates
+            Just (Just u,v) -> do
+                v' <- v
+                u' <- u
+                sim (methName:mcs) (cont v') updates (u':fupdates)
+            Nothing -> case lookup methName meths of
+                Nothing -> error ("Method " ++ methName ++ " not found.")
+                Just f -> do
+                    currEnv <- readIORef envRef
+                    (nextEnv, v) <- f currEnv arg' state regs
+                    writeIORef envRef nextEnv
+                    sim (methName:mcs) (cont v) updates fupdates
 
-    sim mcs (T.LetExpr _ e cont) updates fupdates = sim mcs (cont $ unsafeCoerce $ (eval e :: Val)) updates fupdates
+    sim mcs (T.LetExpr _ e cont) updates fupdates = do
+        v <- eval e
+        sim mcs (cont $ unsafeCoerce $ (v :: Val)) updates fupdates
 
     sim mcs (T.LetAction _ a cont) updates fupdates = do
         (mcs', updates', fupdates', v) <- sim mcs a updates fupdates
@@ -70,18 +81,23 @@ simulate_action methcalls modes envRef state meths act regs = sim methcalls act 
 
     sim mcs (T.WriteReg regName _ e a) updates fupdates = case M.lookup regName regs of
         Nothing -> error ("Register " ++ regName ++ " not found.")
-        Just _ -> sim mcs a ((regName, eval e):updates) fupdates
-        
-    sim mcs (T.IfElse e _ a1 a2 cont) updates fupdates = let a = if (boolCoerce $ eval e) then a1 else a2 in
-        do
-            (mcs',updates',fupdates',v) <- sim mcs a updates fupdates
-            sim mcs' (cont v) updates' fupdates'
+        Just _ -> do
+            v <- eval e
+            sim mcs a ((regName, v):updates) fupdates
+
+    sim mcs (T.IfElse e _ a1 a2 cont) updates fupdates = do
+        b <- eval e
+        let a = if boolCoerce b then a1 else a2
+        (mcs',updates',fupdates',v) <- sim mcs a updates fupdates
+        sim mcs' (cont v) updates' fupdates'
 
     sim mcs (T.Sys syss a) updates fupdates = do
         execIOs $ map (sysIO modes) syss
         sim mcs a updates fupdates
 
-    sim mcs (T.Return e) updates fupdates = return (mcs, updates, fupdates, eval e)
+    sim mcs (T.Return e) updates fupdates = do
+        v <- eval e
+        return (mcs, updates, fupdates, v)
 
 simulate_module :: AbstractEnvironment a => Int -> ([T.RuleT] -> Str (IO T.RuleT)) -> IORef a -> [String] -> [(String, a -> Val -> FileState -> M.Map String Val -> IO (a, Val))] -> [T.RegFileBase] -> T.BaseModule -> IO (M.Map String Val)
 simulate_module _ _ _ _ _ _ (T.BaseRegFile _) = error "BaseRegFile encountered."
@@ -106,5 +122,5 @@ simulate_module seed strategy envRef rulenames meths rfbs (T.BaseMod init_regs r
                     postEnv <- readIORef envRef
                     nextEnv <- envPost postEnv filestate regs ruleName
                     writeIORef envRef nextEnv
-                    sim mcs' rs (updates regs upd) (exec_file_updates filestate fupd)
-
+                    s <- exec_file_updates filestate fupd
+                    sim mcs' rs (updates regs upd) s

--- a/Simulator/Util.hs
+++ b/Simulator/Util.hs
@@ -105,10 +105,10 @@ slice i_0 size arr = do
     vals <- sequence $ map (\j -> MA.readArray arr (i_0 + j)) [0..(size-1)]
     MA.newListArray (0,size-1) vals
 
-arr_length :: (MA.MArray a e m, MA.Ix i) => a i e -> m Int
+arr_length :: (MA.MArray a e m) => a Int e -> m Int
 arr_length arr = do
-    es <- MA.getElems arr
-    return $ length es
+    (i,j) <- MA.getBounds arr
+    return (j - i)
 
 {-
 debug_mode :: IO Bool

--- a/Simulator/Util.hs
+++ b/Simulator/Util.hs
@@ -5,9 +5,16 @@ import qualified Data.HashMap as M
 import qualified Data.BitVector as BV
 import qualified Data.Text as T
 
+import qualified Data.Array.MArray as MA
+
+import Control.Monad
 import Data.Hashable
 import Data.Text.Read (hexadecimal)
 import System.Environment (getArgs)
+
+
+pair_sequence :: Monad m => [(a,m b)] -> m [(a,b)]
+pair_sequence xs = sequence $ map (\(a,m) -> m >>= (\b -> return (a,b))) xs
 
 space_pad :: Int -> String -> String
 space_pad n str = replicate (n - length str) ' ' ++ str
@@ -89,6 +96,19 @@ get_modes = do
         , interactive_mode = "--interactive" `elem` args
         , no_print_mode = "--noprint" `elem` args
     }
+
+do_writes :: (MA.MArray a e m, MA.Ix i) => a i e -> [(i,e)] -> m ()
+do_writes a ps = foldM (\_ (i,e) -> MA.writeArray a i e) () ps
+
+slice :: (MA.MArray a e m) => Int -> Int -> a Int e -> m (a Int e)
+slice i_0 size arr = do
+    vals <- sequence $ map (\j -> MA.readArray arr (i_0 + j)) [0..(size-1)]
+    MA.newListArray (0,size-1) vals
+
+arr_length :: (MA.MArray a e m, MA.Ix i) => a i e -> m Int
+arr_length arr = do
+    es <- MA.getElems arr
+    return $ length es
 
 {-
 debug_mode :: IO Bool

--- a/Simulator/Util.hs
+++ b/Simulator/Util.hs
@@ -11,10 +11,11 @@ import Control.Monad
 import Data.Hashable
 import Data.Text.Read (hexadecimal)
 import System.Environment (getArgs)
+import System.IO.Unsafe (unsafePerformIO)
 
-
-pair_sequence :: Monad m => [(a,m b)] -> m [(a,b)]
-pair_sequence xs = sequence $ map (\(a,m) -> m >>= (\b -> return (a,b))) xs
+pair_sequence ::  [(a,IO b)] ->  IO [(a,b)]
+--pair_sequence xs = sequence $ map (\(a,m) -> m >>= (\b -> return (a,b))) xs
+pair_sequence xs = return $ map (\(a,m) -> (a, unsafePerformIO m)) xs
 
 space_pad :: Int -> String -> String
 space_pad n str = replicate (n - length str) ' ' ++ str

--- a/Simulator/Value.hs
+++ b/Simulator/Value.hs
@@ -15,7 +15,26 @@ import System.Random (randomRIO)
 
 import Debug.Trace
 
-data Val = BoolVal Bool | BVVal BV.BV | StructVal [(String,Val)] | ArrayVal (A.IOArray Int Val) deriving (Eq)
+data Val = BoolVal Bool | BVVal BV.BV | StructVal [(String,Val)] | ArrayVal (A.IOArray Int Val) --deriving (Eq)
+
+(.==) :: Val -> Val -> IO Bool
+(.==) (BoolVal b1) (BoolVal b2) = return $ b1 == b2
+(.==) (BVVal bv1) (BVVal bv2) = return $ bv1 == bv2
+(.==) (StructVal ps1) (StructVal ps2) = do
+    let names1 = map fst ps1
+    let names2 = map fst ps2
+    let b1 = names1 == names2
+    let vals1 = map snd ps1
+    let vals2 = map snd ps2
+    bs <- sequence $ zipWith (.==) vals1 vals2
+    return $ b1 && foldr (&&) True bs
+(.==) (ArrayVal arr1) (ArrayVal arr2) = do
+    es1 <- M.getElems arr1
+    es2 <- M.getElems arr2
+    bs <- sequence $ zipWith (.==) es1 es2
+    return $ foldr (&&) True bs
+(.==) _ _ = return False
+
 
 boolCoerce :: Val -> Bool
 boolCoerce (BoolVal b) = b

--- a/Simulator/Value.hs
+++ b/Simulator/Value.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 
 module Simulator.Value where
 
@@ -5,45 +6,50 @@ import Simulator.Util
 
 import qualified HaskellTarget as T
 
-import qualified Data.Vector as V
+--import qualified Data.Vector as V
+import Data.Array.IO as A
+import Data.Array.MArray as M
 import qualified Data.BitVector as BV
-
+import  Control.Monad
 import System.Random (randomRIO)
 
 import Debug.Trace
 
-data Val = BoolVal Bool | BVVal BV.BV | StructVal [(String,Val)] | ArrayVal (V.Vector Val) deriving (Eq,Show)
+data Val = BoolVal Bool | BVVal BV.BV | StructVal [(String,Val)] | ArrayVal (A.IOArray Int Val) deriving (Eq)
 
 boolCoerce :: Val -> Bool
 boolCoerce (BoolVal b) = b
-boolCoerce v = error $ "Encountered a non-boolean value when a boolean was expected. " ++ show v
+boolCoerce v = error $ "Encountered a non-boolean value when a boolean was expected. "
 
 bvCoerce :: Val -> BV.BV
 bvCoerce (BVVal bs) = bs
-bvCoerce v = error $ "Encountered a non-bitvector value when a bitvector was expected. " ++ show v
+bvCoerce v = error $ "Encountered a non-bitvector value when a bitvector was expected. "
 
 structCoerce :: Val -> [(String,Val)]
 structCoerce (StructVal fields) = fields
-structCoerce v = error $ "Encountered a non-struct value when a struct was expected. " ++ show v
+structCoerce v = error $ "Encountered a non-struct value when a struct was expected. "
 
-arrayCoerce :: Val -> V.Vector Val
+arrayCoerce :: Val -> A.IOArray Int Val
 arrayCoerce (ArrayVal vs) = vs
-arrayCoerce v = error $ "Encountered a non-array value when an array was expected. " ++ show v
+arrayCoerce v = error $ "Encountered a non-array value when an array was expected. "
 
 struct_field_access :: String -> Val -> Val
 struct_field_access fieldName v =
     case lookup fieldName $ structCoerce v of
         Just v' -> v'
-        _ -> error $ "Field " ++ fieldName ++ " not found." ++ show v
+        _ -> error $ "Field " ++ fieldName ++ " not found."
 
-defVal :: T.Kind -> Val
-defVal T.Bool = BoolVal False
-defVal (T.Bit n) = BVVal $ BV.zeros n
-defVal (T.Struct n kinds names) = StructVal $ map (\i -> (names i, defVal $ kinds i)) $ T.getFins n
-defVal (T.Array n k) = ArrayVal $ (V.replicate n $ defVal k)
+defVal :: T.Kind -> IO Val
+defVal T.Bool = return $ BoolVal False
+defVal (T.Bit n) = return $ BVVal $ BV.zeros n
+defVal (T.Struct n kinds names) =
+    liftM StructVal $ pair_sequence $ map (\i -> (names i, defVal $ kinds i)) $ T.getFins n
+defVal (T.Array n k) = do
+    v <- defVal k
+    liftM ArrayVal $ M.newArray (0,n-1)  v
 
-defVal_FK :: T.FullKind -> Val
-defVal_FK (T.NativeKind c) = T.unsafeCoerce c
+defVal_FK :: T.FullKind -> IO Val
+defVal_FK (T.NativeKind c) = return $ T.unsafeCoerce c
 defVal_FK (T.SyntaxKind k) = defVal k
 
 randVal :: T.Kind -> IO Val
@@ -59,9 +65,11 @@ randVal (T.Struct n ks names) = do
     vs <- mapM randVal ks'
     return $ StructVal $ zip names' vs
 randVal (T.Array n k) = do
---    vs <- V.mapM randVal (V.replicate n k)
-    vs <- V.replicateM n (randVal k)
-    return $ ArrayVal vs
+    ps <- mapM (\i -> (randVal k) >>= (\v -> return (i,v))) [0..(n-1)]
+    v <- defVal k
+    arr <- M.newArray (0,(n-1)) v
+    do_writes arr ps
+    return $ ArrayVal arr
 
 -- -- for debugging purposes
 


### PR DESCRIPTION
- Replacing Vectors with IOArrays
- Leaving most of the new IO types in place;  I'm pretty sure using `unsafePerformIO` everywhere lead to bugs with the `SyncNotIsAddr` stuff, so I changed everything back again and only added `unsafePerformIO` in the function `pair_sequence` in `Util.hs`.  Most of the performance gains are still there but it is a bit slower (4m50s vs 4m20s on `rv32ui-v-add` for instance).  I'm sure that could still be improved but I just want these changes to finally be pushed to master. 